### PR TITLE
add browser_sync.js config item feature

### DIFF
--- a/lib/browser_sync_rails/runner.rb
+++ b/lib/browser_sync_rails/runner.rb
@@ -5,7 +5,7 @@ module BrowserSyncRails
     end
 
     def cli_command
-      "browser-sync start --proxy #{host}:#{port} --files '#{files}'"
+      "browser-sync start --proxy #{host}:#{port} --files '#{files}' #{config}"
     end
 
     private
@@ -24,6 +24,15 @@ module BrowserSyncRails
         (files | @options[:files]).join(', ')
       else
         files.join(', ')
+      end
+    end
+
+    def config
+      config_file = @options[:config] || File.join(Rails.root, 'config', 'browser_sync.js')
+      if File.exist?(config_file)
+        "--config #{config_file}"
+      else
+        ""
       end
     end
   end

--- a/lib/generators/browser_sync_rails/install_generator.rb
+++ b/lib/generators/browser_sync_rails/install_generator.rb
@@ -18,6 +18,21 @@ module BrowserSyncRails
         end
 
         create_file "config/browser_sync.yml"
+        create_file "config/browser_sync.js" do
+%q[
+module.exports = {
+    snippetOptions: {
+        rule: {
+            match: /<\/head>/i,
+            fn: function (snippet, match) {
+              return snippet + match;
+            }
+        }
+    }
+}
+]
+        end
+
       end
 
       private


### PR DESCRIPTION
I needed to figure out how to address a turbolinks related issue that causes clicking on links to fail with a javascript exception.

This patch addresses the above, common issue, by introducing a generated 'browser_sync.js' that is added to the browser_sync command line as a "--config <path>" option.

I hope this patch is helpful.